### PR TITLE
Switch from Python.h to milksnake+cffi

### DIFF
--- a/LKH-2.0.9/SRC/INCLUDE/elkai.h
+++ b/LKH-2.0.9/SRC/INCLUDE/elkai.h
@@ -1,0 +1,1 @@
+int InvokeSolver(int *matrixBuff, int matrixLen, int runCount, int *tourBuff, int *tourN);

--- a/LKH-2.0.9/SRC/Makefile
+++ b/LKH-2.0.9/SRC/Makefile
@@ -44,21 +44,22 @@ _OBJ = Activate.o AddCandidate.o AddExtraCandidates.o                  \
        SolveSubproblemBorderProblems.o SolveTourSegmentSubproblems.o   \
        Statistics.o StoreTour.o SymmetrizeCandidateSet.o               \
        TrimCandidateSet.o WriteCandidates.o WritePenalties.o           \
-       WriteTour.o MergeWithTourGPX2.o gpx.o
+       WriteTour.o MergeWithTourGPX2.o gpx.o elkai.o
              
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 $(ODIR)/%.o: %.c $(DEPS)
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -fPIC -c -o $@ $< $(CFLAGS)
 
 .PHONY: 
 	all clean
 
 all:
+	mkdir -p OBJ
 	$(MAKE) LKH
 
 LKH: $(OBJ) $(DEPS)
-	$(CC) -o ../LKH $(OBJ) $(CFLAGS) -lm
+	$(CC) -shared -fPIC -o ../libelkai.so $(OBJ) $(CFLAGS) -lm
 
 clean:
 	/bin/rm -f $(ODIR)/*.o ../LKH *~ ._* $(IDIR)/*~ $(IDIR)/._* 

--- a/LKH-2.0.9/SRC/elkai.c
+++ b/LKH-2.0.9/SRC/elkai.c
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include "LKH.h"
 #include "Genetic.h"
 #include "math.h"
@@ -11,89 +10,6 @@
 // - LKH feature: Add known optimal subtours?
 // - Make sure camel case is used everywhere
 // - Use git submodule instead of a LKH copy
-
-static int InvokeSolver(int *matrixBuff, int matrixLen, int runCount, int *tourBuff, int *tourN);
-
-static PyObject *ElkSolve(PyObject *self, PyObject *args)
-{
-    // *args of a vararg Python function is a tuple
-    // of unknown length.
-
-    if(PyObject_Length(args) != 2) {
-        PyErr_SetString(PyExc_TypeError, "Expected two arguments");
-        return 0;
-    }
-
-    PyObject *arg = PyObject_GetItem(args, PyLong_FromLong(0));
-    PyObject *runArg = PyObject_GetItem(args, PyLong_FromLong(1));
-
-    long runCount = PyLong_AsLong(runArg);
-    if(PyErr_Occurred() != 0 || runCount <= 0) {
-        PyErr_SetString(PyExc_TypeError, "Second argument must be a positive int");
-        return 0;
-    } 
-
-    int pyLen = PyObject_Length(arg);
-
-    // We get the problem dimension as a square root of the flat NxN
-    // matrix length. It could be done using recursive bit shifts too.
-
-    int pyLenSqrt = (int)sqrt(pyLen);
-    if (pyLen < 4 || pyLenSqrt * pyLenSqrt != pyLen)
-    {
-        PyErr_SetString(PyExc_TypeError, "Argument must be a list of integers with N^2 >= 4 elements.\n"
-                                          "Example: [1, 1, 1, 1].");
-        return 0;
-    }
-    int *matrixBuff = (int *)malloc(sizeof(int) * pyLen);
-    int *tourBuff = (int *)malloc(sizeof(int) * pyLenSqrt);
-    int tourN = 0;
-
-    long i;
-    for (i = 0; i < pyLen; i++)
-    {
-        PyObject *pyNumber = PyObject_GetItem(arg, PyLong_FromLong(i));
-        long justNumber = PyLong_AsLong(pyNumber);
-        if(PyErr_Occurred() != 0) {
-            PyErr_SetString(PyExc_TypeError, "List must only contain integers");
-            return 0;
-        }
-        int justNumber_i = (int)justNumber;
-        // TODO: don't lose precision
-        matrixBuff[i] = justNumber_i;
-    }
-    int norm_result = InvokeSolver(matrixBuff, pyLen, runCount, tourBuff, &tourN);
-    free(matrixBuff);
-    PyObject *list = PyList_New(tourN);
-    for (i = 0; i < tourN; i++)
-    {
-        PyObject *tourElement = PyLong_FromLong((long)tourBuff[i]);
-        PyList_SetItem(list, i, tourElement);
-    }
-
-    free(tourBuff);
-    return list;
-}
-
-static char elk_docs[] =
-    "solve(x): Solve a TSP problem.\n";
-
-static PyMethodDef funcs[] = {
-    {"solve", (PyCFunction) ElkSolve,
-     METH_VARARGS, elk_docs},
-    {NULL}};
-
-static struct PyModuleDef elkDef = {
-    PyModuleDef_HEAD_INIT,
-    "_elkai",
-    "",
-    -1,
-    funcs};
-
-PyMODINIT_FUNC PyInit__elkai(void)
-{
-    return PyModule_Create(&elkDef);
-}
 
 static void LoadWeightMatrix(int *arr);
 
@@ -483,7 +399,7 @@ void _Reset8();
 
 // InvokeSolver reads the matrix buffer and outputs it into tourBuff and updates
 // tourN which is the tour length.
-static int InvokeSolver(int *matrixBuff, int matrixLen, int runCount, int *tourBuff, int *tourN)
+int InvokeSolver(int *matrixBuff, int matrixLen, int runCount, int *tourBuff, int *tourN)
 {
     _Reset1();
     _Reset2();

--- a/elkai/_elkai.py
+++ b/elkai/_elkai.py
@@ -1,0 +1,17 @@
+from ._native import lib as _lib, ffi as _ffi
+
+
+def solve(x, runCount):
+    """solve(x): Solve a TSP problem.\n"""
+    n = int(len(x) ** .5)
+    if len(x) < 4 or len(x) != n ** 2:
+        raise TypeError(
+            "Argument must be a list of integers with N^2 >= 4 elements.\n"
+            + "Example: [1, 1, 1, 1]."
+        )
+
+    matrixBuff = _ffi.new("int[%s]" % len(x), x)
+    tourBuff = _ffi.new("int[%s]" % n)
+    tourN = _ffi.new("int*")
+    norm_result = _lib.InvokeSolver(matrixBuff, len(x), runCount, tourBuff, tourN)
+    return list(tourBuff[0:tourN[0]])

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,20 @@
-from skbuild import setup
+from setuptools import setup
 from os import path
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+def build_native(spec):
+    build = spec.add_external_build(
+        cmd=["make"],
+        path="./LKH-2.0.9/SRC",
+    )
+
+    spec.add_cffi_module(
+        module_path="elkai._native",
+        dylib=lambda: build.find_dylib("elkai", in_path=".."),
+        header_filename=lambda: build.find_header("elkai.h", in_path="INCLUDE"),
+    )
 
 setup(
     name="elkai",
@@ -14,4 +26,12 @@ setup(
     packages=['elkai'],
     author="Filip Dimitrovski",
     license="MIT",
+    include_package_data=True,
+    zip_safe=False,
+    platforms='any',
+    install_requires=['milksnake'],
+    setup_requires=['milksnake'],
+    milksnake_tasks=[
+        build_native,
+    ],
 )


### PR DESCRIPTION
This allows `setup.py bdist_wheel` to create a wheel that is independent
of the Python version.

Move `InvokeSolver()` from `_elkai.c` into `LKH-2.0.9/SRC/elkai.c`,
and reimplement `solve()` in `elkai/_elkai.py`.

Update `LKH-2.0.9/SRC/Makefile` to build a shared library named
`libelkai.so` (instead of trying to build an executable without `main`).

Update `setup.py` to invoke `make` and generate CFFI bindings for
`LKH-2.0.9/SRC/INCLUDE/elkai.h` (which only declares `InvokeSolver()`).